### PR TITLE
Extremely slow compilation and evaluation of 33 operand sum

### DIFF
--- a/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/DefaultNode.java
+++ b/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/DefaultNode.java
@@ -36,6 +36,7 @@ public class DefaultNode extends AExpressionNode implements ExpressionNode {
 
   private ExpressionNode expression;
   private ExpressionNode defaultExpression;
+  private Type cachedValueType;
 
   @Override
   public DefaultNode copy() {
@@ -52,6 +53,7 @@ public class DefaultNode extends AExpressionNode implements ExpressionNode {
 
   public DefaultNode setExpression(ExpressionNode expression) {
     this.expression = expression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -61,6 +63,7 @@ public class DefaultNode extends AExpressionNode implements ExpressionNode {
 
   public DefaultNode setDefaultExpression(ExpressionNode defaultExpression) {
     this.defaultExpression = defaultExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -76,8 +79,10 @@ public class DefaultNode extends AExpressionNode implements ExpressionNode {
 
   @Override
   public Type getValueType() {
-    if (expression.getValueType() == defaultExpression.getValueType()) return expression.getValueType();
-    return Types.ANY;
+    if (cachedValueType != null) return cachedValueType;
+    Type et = expression.getValueType();
+    Type dt = defaultExpression.getValueType();
+    return cachedValueType = (et == dt) ? et : Types.ANY;
   }
 
   @Override

--- a/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/MinusNode.java
+++ b/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/MinusNode.java
@@ -37,6 +37,7 @@ public class MinusNode extends AExpressionNode implements ExpressionNode {
 
   private ExpressionNode leftExpression;
   private ExpressionNode rightExpression;
+  private Type cachedValueType;
 
   @Override
   public MinusNode copy() {
@@ -53,6 +54,7 @@ public class MinusNode extends AExpressionNode implements ExpressionNode {
 
   public MinusNode setLeftExpression(ExpressionNode leftExpression) {
     this.leftExpression = leftExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -62,6 +64,7 @@ public class MinusNode extends AExpressionNode implements ExpressionNode {
 
   public MinusNode setRightExpression(ExpressionNode rightExpression) {
     this.rightExpression = rightExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -82,14 +85,15 @@ public class MinusNode extends AExpressionNode implements ExpressionNode {
       return expressionOp.eval(null, null).type();
     }
 
-    if (leftExpression.getValueType() == Types.LONG && rightExpression.getValueType() == Types.LONG){
-      return Types.LONG;
-    }
-    if (leftExpression.getValueType() == Types.DOUBLE || rightExpression.getValueType() == Types.DOUBLE){
-      return Types.DOUBLE;
-    }
+    if (cachedValueType != null) return cachedValueType;
 
-    return Types.ANY;
+    Type lt = leftExpression.getValueType();
+    Type rt = rightExpression.getValueType();
+
+    if (lt == Types.LONG && rt == Types.LONG) return cachedValueType = Types.LONG;
+    if (lt == Types.DOUBLE || rt == Types.DOUBLE) return cachedValueType = Types.DOUBLE;
+
+    return cachedValueType = Types.ANY;
   }
 
   @Override

--- a/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/ModNode.java
+++ b/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/ModNode.java
@@ -37,6 +37,7 @@ public class ModNode extends AExpressionNode implements ExpressionNode {
 
   private ExpressionNode leftExpression;
   private ExpressionNode rightExpression;
+  private Type cachedValueType;
 
   @Override
   public ModNode copy() {
@@ -53,6 +54,7 @@ public class ModNode extends AExpressionNode implements ExpressionNode {
 
   public ModNode setLeftExpression(ExpressionNode leftExpression) {
     this.leftExpression = leftExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -62,6 +64,7 @@ public class ModNode extends AExpressionNode implements ExpressionNode {
 
   public ModNode setRightExpression(ExpressionNode rightExpression) {
     this.rightExpression = rightExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -82,14 +85,15 @@ public class ModNode extends AExpressionNode implements ExpressionNode {
       return expressionOp.eval(null, null).type();
     }
 
-    if (leftExpression.getValueType() == Types.LONG && rightExpression.getValueType() == Types.LONG){
-      return Types.LONG;
-    }
-    if (leftExpression.getValueType() == Types.DOUBLE || rightExpression.getValueType() == Types.DOUBLE){
-      return Types.DOUBLE;
-    }
+    if (cachedValueType != null) return cachedValueType;
 
-    return Types.ANY;
+    Type lt = leftExpression.getValueType();
+    Type rt = rightExpression.getValueType();
+
+    if (lt == Types.LONG && rt == Types.LONG) return cachedValueType = Types.LONG;
+    if (lt == Types.DOUBLE || rt == Types.DOUBLE) return cachedValueType = Types.DOUBLE;
+
+    return cachedValueType = Types.ANY;
   }
 
   @Override

--- a/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/MultNode.java
+++ b/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/MultNode.java
@@ -37,6 +37,7 @@ public class MultNode extends AExpressionNode implements ExpressionNode {
 
   private ExpressionNode leftExpression;
   private ExpressionNode rightExpression;
+  private Type cachedValueType;
 
   @Override
   public MultNode copy() {
@@ -53,6 +54,7 @@ public class MultNode extends AExpressionNode implements ExpressionNode {
 
   public MultNode setLeftExpression(ExpressionNode leftExpression) {
     this.leftExpression = leftExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -62,6 +64,7 @@ public class MultNode extends AExpressionNode implements ExpressionNode {
 
   public MultNode setRightExpression(ExpressionNode rightExpression) {
     this.rightExpression = rightExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -82,14 +85,15 @@ public class MultNode extends AExpressionNode implements ExpressionNode {
       return expressionOp.eval(null, null).type();
     }
 
-    if (leftExpression.getValueType() == Types.LONG && rightExpression.getValueType() == Types.LONG){
-      return Types.LONG;
-    }
-    if (leftExpression.getValueType() == Types.DOUBLE || rightExpression.getValueType() == Types.DOUBLE){
-      return Types.DOUBLE;
-    }
+    if (cachedValueType != null) return cachedValueType;
 
-    return Types.ANY;
+    Type lt = leftExpression.getValueType();
+    Type rt = rightExpression.getValueType();
+
+    if (lt == Types.LONG && rt == Types.LONG) return cachedValueType = Types.LONG;
+    if (lt == Types.DOUBLE || rt == Types.DOUBLE) return cachedValueType = Types.DOUBLE;
+
+    return cachedValueType = Types.ANY;
   }
 
   @Override

--- a/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/PlusNode.java
+++ b/src/main/java/com/twineworks/tweakflow/lang/ast/expressions/PlusNode.java
@@ -37,6 +37,7 @@ public class PlusNode extends AExpressionNode implements ExpressionNode {
 
   private ExpressionNode leftExpression;
   private ExpressionNode rightExpression;
+  private Type cachedValueType;
 
   @Override
   public PlusNode copy() {
@@ -53,6 +54,7 @@ public class PlusNode extends AExpressionNode implements ExpressionNode {
 
   public PlusNode setLeftExpression(ExpressionNode leftExpression) {
     this.leftExpression = leftExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -62,6 +64,7 @@ public class PlusNode extends AExpressionNode implements ExpressionNode {
 
   public PlusNode setRightExpression(ExpressionNode rightExpression) {
     this.rightExpression = rightExpression;
+    this.cachedValueType = null;
     return this;
   }
 
@@ -82,14 +85,15 @@ public class PlusNode extends AExpressionNode implements ExpressionNode {
       return expressionOp.eval(null, null).type();
     }
 
-    if (leftExpression.getValueType() == Types.LONG && rightExpression.getValueType() == Types.LONG){
-      return Types.LONG;
-    }
-    if (leftExpression.getValueType() == Types.DOUBLE || rightExpression.getValueType() == Types.DOUBLE){
-      return Types.DOUBLE;
-    }
+    if (cachedValueType != null) return cachedValueType;
 
-    return Types.ANY;
+    Type lt = leftExpression.getValueType();
+    Type rt = rightExpression.getValueType();
+
+    if (lt == Types.LONG && rt == Types.LONG) return cachedValueType = Types.LONG;
+    if (lt == Types.DOUBLE || rt == Types.DOUBLE) return cachedValueType = Types.DOUBLE;
+
+    return cachedValueType = Types.ANY;
   }
 
   @Override

--- a/src/test/resources/fixtures/tweakflow/evaluation/operators/default.tf
+++ b/src/test/resources/fixtures/tweakflow/evaluation/operators/default.tf
@@ -12,4 +12,41 @@ library operator_spec {
   ca_p:  [1,2,3][2] default "x"  == 3;
   fn_d:  lib.f(nil) default "x"  == "x";
 
+  let_many_defaults:
+    let {
+      n1: nil;
+      n2: nil;
+      n3: nil;
+      n4: nil;
+      n5: nil;
+      n6: nil;
+      n7: nil;
+      n8: nil;
+      n9: nil;
+      n10: nil;
+      n11: nil;
+      n12: nil;
+      n13: nil;
+      n14: nil;
+      n15: nil;
+      n16: nil;
+      n17: nil;
+      n18: nil;
+      n19: nil;
+      n20: nil;
+      n21: nil;
+      n22: nil;
+      n23: nil;
+      n24: nil;
+      n25: nil;
+      n26: nil;
+      n27: nil;
+      n28: nil;
+      n29: nil;
+      n30: nil;
+      n31: nil;
+      n32: nil;
+      n33: nil;
+      s: (n1 default 0) + (n2 default 0) + (n3 default 0) + (n4 default 0) + (n5 default 0) + (n6 default 0) + (n7 default 0) + (n8 default 0) + (n9 default 0) + (n10 default 0) + (n11 default 0) + (n12 default 0) + (n13 default 0) + (n14 default 0) + (n15 default 0) + (n16 default 0) + (n17 default 0) + (n18 default 0) + (n19 default 0) + (n20 default 0) + (n21 default 0) + (n22 default 0) + (n23 default 0) + (n24 default 0) + (n25 default 0) + (n26 default 0) + (n27 default 0) + (n28 default 0) + (n29 default 0) + (n30 default 0) + (n31 default 0) + (n32 default 0) + (n33 default 0);
+    } s == 0;
 }


### PR DESCRIPTION
Hi,

I encountered extremely slow evaluation of a simple sum of >30 operands (I was able to narrow it down from 80 operands - don't ask :)) 

Try to evaluate this expression in `bin/repl`:
```
let { n1: nil; n2: nil; n3: nil; n4: nil; n5: nil; n6: nil; n7: nil; n8: nil; n9: nil; n10: nil; n11: nil; n12: nil; n13: nil; n14: nil; n15: nil; n16: nil; n17: nil; n18: nil; n19: nil; n20: nil; n21: nil; n22: nil; n23: nil; n24: nil; n25: nil; n26: nil; n27: nil; n28: nil; n29: nil; n30: nil; n31: nil; n32: nil; n33: nil; s: (n1 default 0) + (n2 default 0) + (n3 default 0) + (n4 default 0) + (n5 default 0) + (n6 default 0) + (n7 default 0) + (n8 default 0) + (n9 default 0) + (n10 default 0) + (n11 default 0) + (n12 default 0) + (n13 default 0) + (n14 default 0) + (n15 default 0) + (n16 default 0) + (n17 default 0) + (n18 default 0) + (n19 default 0) + (n20 default 0) + (n21 default 0) + (n22 default 0) + (n23 default 0) + (n24 default 0) + (n25 default 0) + (n26 default 0) + (n27 default 0) + (n28 default 0) + (n29 default 0) + (n30 default 0) + (n31 default 0) + (n32 default 0) + (n33 default 0); } s
```

It takes ~20s on my laptop. 

The thread dump shows:
```
"DefaultDispatcher-worker-1 @coroutine#11@13763" daemon prio=5 tid=0x3e nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:85)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.getValueType(PlusNode.java:88)
	at com.twineworks.tweakflow.lang.interpreter.ops.PlusOp.specialize(PlusOp.java:139)
	at com.twineworks.tweakflow.lang.analysis.ops.OpSpecializationVisitor.specialize(OpSpecializationVisitor.java:36)
	at com.twineworks.tweakflow.lang.analysis.ops.OpSpecializationVisitor.visit(OpSpecializationVisitor.java:151)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.accept(PlusNode.java:75)
	at com.twineworks.tweakflow.lang.ast.expressions.PlusNode.accept(PlusNode.java:36)
	at com.twineworks.tweakflow.lang.analysis.visitors.AExpressionDescendingVisitor.lambda$visit$31(AExpressionDescendingVisitor.java:312)
	at com.twineworks.tweakflow.lang.analysis.visitors.AExpressionDescendingVisitor$$Lambda/0x0000000071e11b60.accept(Unknown Source:-1)
	at java.util.Arrays$ArrayList.forEach(Arrays.java:4264)
```	

I added a test in `OperatorTest` which confirmed the performance issue
> [INFO] Running com.twineworks.tweakflow.operators.OperatorTest
[INFO] Tests run: 2182, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: **18.984 s** - in com.twineworks.tweakflow.operators.OperatorTest

Further investigation with Claude Code concluded the the following cause:

Plus/Minus/Mult/Mod/Default nodes recursed into children on each getValueType() call with no caching, causing exponential blowup on left-leaning operator chains (e.g. 33 chained `x default 0` terms summed with `+` took ~17s to analyze). Cache the computed type in each node and invalidate it in the child setters.

